### PR TITLE
Distributed mnist example fails to run

### DIFF
--- a/examples/mnist/configmap.yaml
+++ b/examples/mnist/configmap.yaml
@@ -92,7 +92,7 @@ data:
         partition = DataPartitioner(dataset, partition_sizes)
         partition = partition.use(dist.get_rank())
         train_set = torch.utils.data.DataLoader(
-            partition, batch_size=bsz, shuffle=True)
+            partition, batch_size=int(bsz), shuffle=True)
         return train_set, bsz
 
 
@@ -121,7 +121,7 @@ data:
                 optimizer.zero_grad()
                 output = model(data)
                 loss = F.nll_loss(output, target)
-                epoch_loss += loss.data[0]
+                epoch_loss += loss.item()
                 loss.backward()
                 average_gradients(model)
                 optimizer.step()


### PR DESCRIPTION
With the latest pytorch, Dataloader argument batch size has to be an integer.
Also, usage of indexing 0-dim Tensor is deprecated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pytorch-operator/36)
<!-- Reviewable:end -->
