### PR TITLE
Adding build_image.sh file for nightly releases

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# A simple script to build the Docker images.
+# This is intended to be invoked as a step in Argo to build the docker image.
+#
+# build_image.sh ${DOCKERFILE} ${IMAGE} ${TAG} {ROOT_DIR}
+set -ex
+
+DOCKERFILE=$1
+CONTEXT_DIR=$(dirname "$DOCKERFILE")
+IMAGE=$2
+TAG=$3
+ROOT_DIR=$4
+GOPATH=${ROOT_DIR}
+GO_DIR=${GOPATH}/src/github.com/kubeflow/pytorch-operator
+gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+
+export PATH=${GOPATH}/bin:/usr/local/go/bin:${PATH}
+echo "Create symlink to GOPATH"
+mkdir -p ${GOPATH}/src/github.com/kubeflow
+ln -s ${CONTEXT_DIR} ${GO_DIR}
+cd ${GO_DIR}
+echo "Build operator binary"
+go build github.com/kubeflow/pytorch-operator/cmd/pytorch-operator
+
+echo "Building container in gcloud"
+gcloud container builds submit . --tag=${IMAGE}:${TAG}
+


### PR DESCRIPTION
Fixes #20

Build_image.sh file is required for building image during nightly
release workflow

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pytorch-operator/39)
<!-- Reviewable:end -->
