### PR TITLE
Minor fix to export the GOPATH variable

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -11,7 +11,7 @@ CONTEXT_DIR=$(dirname "$DOCKERFILE")
 IMAGE=$2
 TAG=$3
 ROOT_DIR=$4
-GOPATH=${ROOT_DIR}
+export GOPATH=${ROOT_DIR}
 GO_DIR=${GOPATH}/src/github.com/kubeflow/pytorch-operator
 gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
 
@@ -25,4 +25,4 @@ go build github.com/kubeflow/pytorch-operator/cmd/pytorch-operator
 
 echo "Building container in gcloud"
 gcloud container builds submit . --tag=${IMAGE}:${TAG}
-
+echo "Image built successfully"


### PR DESCRIPTION
GOPath has to be exported to be picked up by the go build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pytorch-operator/41)
<!-- Reviewable:end -->
