### PR TITLE
Incorrect tag used with pytorch_job_mnist.yaml example

### DIFF
--- a/examples/dist-mnist/pytorch_job_mnist.yaml
+++ b/examples/dist-mnist/pytorch_job_mnist.yaml
@@ -11,7 +11,7 @@ spec:
       template:
         spec:
           containers:
-          - image: gcr.io/kubeflow-examples/pytorch-dist-mnist:v20180702-4996efd
+          - image: gcr.io/kubeflow-examples/pytorch-dist-mnist:v20180702-a57993c
             imagePullPolicy: IfNotPresent
             name: pytorch
           restartPolicy: OnFailure
@@ -20,7 +20,7 @@ spec:
       template:
         spec:
           containers:
-          - image: gcr.io/kubeflow-examples/pytorch-dist-mnist:v20180702-4996efd
+          - image: gcr.io/kubeflow-examples/pytorch-dist-mnist:v20180702-a57993c
             imagePullPolicy: IfNotPresent
             name: pytorch
           restartPolicy: OnFailure

--- a/examples/dist-mnist/pytorch_job_mnist.yaml
+++ b/examples/dist-mnist/pytorch_job_mnist.yaml
@@ -11,7 +11,7 @@ spec:
       template:
         spec:
           containers:
-          - image: gcr.io/kubeflow-examples/pytorch-dist-mnist:v20180702-a57993c
+          - image: gcr.io/kubeflow-ci/pytorch-dist-mnist_test:1.0
             imagePullPolicy: IfNotPresent
             name: pytorch
           restartPolicy: OnFailure
@@ -20,7 +20,7 @@ spec:
       template:
         spec:
           containers:
-          - image: gcr.io/kubeflow-examples/pytorch-dist-mnist:v20180702-a57993c
+          - image: gcr.io/kubeflow-ci/pytorch-dist-mnist_test:1.0
             imagePullPolicy: IfNotPresent
             name: pytorch
           restartPolicy: OnFailure


### PR DESCRIPTION
Updating the example to use the available image at 
 https://console.cloud.google.com/gcr/images/kubeflow-examples/GLOBAL/pytorch-dist-mnist

At the moment the image cannot be found and results in the pod being unable to start.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pytorch-operator/51)
<!-- Reviewable:end -->
