### PR TITLE
Changing Default RestartPolicy and  CleanPodPolicy for PyTorch Job

### DIFF
--- a/pkg/apis/pytorch/v1alpha2/constants.go
+++ b/pkg/apis/pytorch/v1alpha2/constants.go
@@ -26,5 +26,5 @@ const (
 	// DefaultPort is default value of the port.
 	DefaultPort = 23456
 	// DefaultRestartPolicy is default RestartPolicy for PyTorchReplicaSpec.
-	DefaultRestartPolicy = RestartPolicyNever
+	DefaultRestartPolicy = RestartPolicyOnFailure
 )

--- a/pkg/apis/pytorch/v1alpha2/defaults.go
+++ b/pkg/apis/pytorch/v1alpha2/defaults.go
@@ -87,8 +87,8 @@ func setTypeNameToCamelCase(job *PyTorchJob, typ PyTorchReplicaType) {
 func SetDefaults_PyTorchJob(job *PyTorchJob) {
 	// Set default cleanpod policy to Running.
 	if job.Spec.CleanPodPolicy == nil {
-		running := CleanPodPolicyRunning
-		job.Spec.CleanPodPolicy = &running
+		policy := CleanPodPolicyNone
+		job.Spec.CleanPodPolicy = &policy
 	}
 
 	// Update the key of PyTorchReplicaSpecs to camel case.

--- a/pkg/apis/pytorch/v1alpha2/types.go
+++ b/pkg/apis/pytorch/v1alpha2/types.go
@@ -88,7 +88,6 @@ type CleanPodPolicy string
 const (
 	CleanPodPolicyUndefined CleanPodPolicy = ""
 	CleanPodPolicyAll       CleanPodPolicy = "All"
-	CleanPodPolicyRunning   CleanPodPolicy = "Running"
 	CleanPodPolicyNone      CleanPodPolicy = "None"
 )
 

--- a/pkg/controller.v2/pytorch/job.go
+++ b/pkg/controller.v2/pytorch/job.go
@@ -82,9 +82,6 @@ func (pc *PyTorchController) deletePodsAndServices(job *v1alpha2.PyTorchJob, pod
 	}
 
 	for _, pod := range pods {
-		if *job.Spec.CleanPodPolicy == v1alpha2.CleanPodPolicyRunning && pod.Status.Phase != v1.PodRunning {
-			continue
-		}
 		if err := pc.PodControl.DeletePod(pod.Namespace, pod.Name, job); err != nil {
 			return err
 		}

--- a/pkg/controller.v2/pytorch/job_test.go
+++ b/pkg/controller.v2/pytorch/job_test.go
@@ -212,44 +212,6 @@ func TestDeletePodsAndServices(t *testing.T) {
 			expectedPodDeletions: 5,
 		},
 		testCase{
-			description: "4 workers and 1 master are running, policy is running",
-			job:         testutil.NewPyTorchJobWithCleanPolicy(1, 4, v1alpha2.CleanPodPolicyRunning),
-
-			pendingWorkerPods:   0,
-			activeWorkerPods:    4,
-			succeededWorkerPods: 0,
-			failedWorkerPods:    0,
-
-			pendingMasterPods:   0,
-			activeMasterPods:    1,
-			succeededMasterPods: 0,
-			failedMasterPods:    0,
-
-			activeWorkerServices: 4,
-			activeMasterServices: 1,
-
-			expectedPodDeletions: 5,
-		},
-		testCase{
-			description: "4 workers and 1 master succeeded, policy is running",
-			job:         testutil.NewPyTorchJobWithCleanPolicy(1, 4, v1alpha2.CleanPodPolicyRunning),
-
-			pendingWorkerPods:   0,
-			activeWorkerPods:    0,
-			succeededWorkerPods: 4,
-			failedWorkerPods:    0,
-
-			pendingMasterPods:   0,
-			activeMasterPods:    0,
-			succeededMasterPods: 1,
-			failedMasterPods:    0,
-
-			activeWorkerServices: 4,
-			activeMasterServices: 1,
-
-			expectedPodDeletions: 0,
-		},
-		testCase{
 			description: "4 workers and 1 master succeeded, policy is None",
 			job:         testutil.NewPyTorchJobWithCleanPolicy(1, 4, v1alpha2.CleanPodPolicyNone),
 

--- a/test/e2e/v1alpha2/main.go
+++ b/test/e2e/v1alpha2/main.go
@@ -44,8 +44,7 @@ func getReplicaSpec(worker int32) map[v1alpha2.PyTorchReplicaType]*v1alpha2.PyTo
 
 func replicaSpec(replica int32) *v1alpha2.PyTorchReplicaSpec {
 	return &v1alpha2.PyTorchReplicaSpec{
-		Replicas:      proto.Int32(replica),
-		RestartPolicy: v1alpha2.RestartPolicyOnFailure,
+		Replicas: proto.Int32(replica),
 		Template: v1.PodTemplateSpec{
 			Spec: v1.PodSpec{
 				Containers: []v1.Container{
@@ -114,8 +113,6 @@ func run() (string, error) {
 			PyTorchReplicaSpecs: getReplicaSpec(3),
 		},
 	}
-	policy := v1alpha2.CleanPodPolicyNone
-	original.Spec.CleanPodPolicy = &policy
 	// Create PyTorchJob
 	_, err = torchJobClient.KubeflowV1alpha2().PyTorchJobs(*namespace).Create(original)
 	if err != nil {


### PR DESCRIPTION
Default RestartPolicy is changed to RestartOnFailure.  If master pod somehow starts late than the workers, pytorch job fails.  We need to restart the workers in such a case.

Default CleanPodPolicy is changed to None. CleanPodRunning is not needed for pytorch. If user needs to delete all pods when they are completed, set to CleanPodPolicyAll or else CleanPodPolicyNone(default) if user wants to retain the pods. 

