### PR TITLE
Adding option for restricting operator scope to namespace level

### DIFF
--- a/cmd/pytorch-operator.v2/app/options/options.go
+++ b/cmd/pytorch-operator.v2/app/options/options.go
@@ -16,6 +16,8 @@ package options
 
 import (
 	"flag"
+
+	"k8s.io/api/core/v1"
 )
 
 // ServerOption is the main context object for the controller manager.
@@ -26,6 +28,7 @@ type ServerOption struct {
 	PrintVersion         bool
 	JSONLogFormat        bool
 	EnableGangScheduling bool
+	Namespace            string
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -39,6 +42,10 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&s.MasterURL, "master", "",
 		`The url of the Kubernetes API server,
 		 will overrides any value in kubeconfig, only required if out-of-cluster.`)
+
+	fs.StringVar(&s.Namespace, "namespace", v1.NamespaceAll,
+		`The namespace to monitor pytorch jobs. If unset, it monitors all namespaces cluster-wide.
+                 If set, it only monitors pytorch jobs in the given namespace.`)
 
 	fs.IntVar(&s.Threadiness, "threadiness", 1,
 		`How many threads to process the main logic`)

--- a/cmd/pytorch-operator.v2/app/server.go
+++ b/cmd/pytorch-operator.v2/app/server.go
@@ -92,10 +92,10 @@ func Run(opt *options.ServerOption) error {
 	}
 
 	// Create informer factory.
-	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClientSet, resyncPeriod)
+	kubeInformerFactory := kubeinformers.NewFilteredSharedInformerFactory(kubeClientSet, resyncPeriod, opt.Namespace, nil)
 	pytorchJobInformerFactory := jobinformers.NewSharedInformerFactory(pytorchJobClientSet, resyncPeriod)
 
-	unstructuredInformer := controller.NewUnstructuredPyTorchJobInformer(kcfg)
+	unstructuredInformer := controller.NewUnstructuredPyTorchJobInformer(kcfg, opt.Namespace)
 
 	// Create pytorch controller.
 	tc := controller.NewPyTorchController(unstructuredInformer, kubeClientSet, pytorchJobClientSet, kubeInformerFactory, pytorchJobInformerFactory, *opt)

--- a/pkg/controller.v2/pytorch/controller_test.go
+++ b/pkg/controller.v2/pytorch/controller_test.go
@@ -57,7 +57,7 @@ func newPyTorchController(
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClientSet, resyncPeriod())
 	jobInformerFactory := jobinformers.NewSharedInformerFactory(jobClientSet, resyncPeriod())
 
-	jobInformer := NewUnstructuredPyTorchJobInformer(config)
+	jobInformer := NewUnstructuredPyTorchJobInformer(config, metav1.NamespaceAll)
 
 	ctr := NewPyTorchController(jobInformer, kubeClientSet, jobClientSet, kubeInformerFactory, jobInformerFactory, option)
 	ctr.PodControl = &controller.FakePodControl{}

--- a/pkg/controller.v2/pytorch/informer.go
+++ b/pkg/controller.v2/pytorch/informer.go
@@ -31,7 +31,7 @@ var (
 	errFailedMarshal = fmt.Errorf("Failed to marshal the object to PyTorchJob")
 )
 
-func NewUnstructuredPyTorchJobInformer(restConfig *restclientset.Config) jobinformersv1alpha2.PyTorchJobInformer {
+func NewUnstructuredPyTorchJobInformer(restConfig *restclientset.Config, namespace string) jobinformersv1alpha2.PyTorchJobInformer {
 	dynClientPool := dynamic.NewDynamicClientPool(restConfig)
 	dclient, err := dynClientPool.ClientForGroupVersionKind(v1alpha2.SchemeGroupVersionKind)
 	if err != nil {
@@ -47,7 +47,7 @@ func NewUnstructuredPyTorchJobInformer(restConfig *restclientset.Config) jobinfo
 	informer := unstructured.NewPyTorchJobInformer(
 		resource,
 		dclient,
-		metav1.NamespaceAll,
+		namespace,
 		resyncPeriod,
 		cache.Indexers{},
 	)


### PR DESCRIPTION
Fixes #58 

Namespace can be given as an extra option to restrict the monitoring to namespace scope instead of the default cluster scope.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pytorch-operator/61)
<!-- Reviewable:end -->
