### PR TITLE
Adding pytorch 0.4 as default

### DIFF
--- a/examples/gloo-dist/mnist/Dockerfile
+++ b/examples/gloo-dist/mnist/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:v0.2
+FROM pytorch/pytorch:0.4_cuda9_cudnn7
 
 ADD . /opt/pytorch_dist_mnist
 ENTRYPOINT ["python", "-u", "/opt/pytorch_dist_mnist/dist_mnist.py"]

--- a/examples/gloo-dist/mnist/dist_mnist.py
+++ b/examples/gloo-dist/mnist/dist_mnist.py
@@ -67,7 +67,7 @@ class Net(nn.Module):
         x = F.relu(self.fc1(x))
         x = F.dropout(x, training=self.training)
         x = self.fc2(x)
-        return F.log_softmax(x)
+        return F.log_softmax(x, dim=1)
 
 
 def partition_dataset():
@@ -115,7 +115,7 @@ def run():
             optimizer.zero_grad()
             output = model(data)
             loss = F.nll_loss(output, target)
-            epoch_loss += loss.data[0]
+            epoch_loss += loss.item()
             loss.backward()
             average_gradients(model)
             optimizer.step()

--- a/examples/smoke-dist/Dockerfile
+++ b/examples/smoke-dist/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:v0.2
+FROM pytorch/pytorch:0.4_cuda9_cudnn7
 
 RUN mkdir -p /opt/mlkube
 COPY dist_sendrecv.py /opt/mlkube/

--- a/examples/tcp-dist/mnist/Dockerfile
+++ b/examples/tcp-dist/mnist/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:v0.2
+FROM pytorch/pytorch:0.4_cuda9_cudnn7
 
 ADD . /opt/pytorch_dist_mnist
 ENTRYPOINT ["python", "/opt/pytorch_dist_mnist/dist_mnist.py"]

--- a/examples/tcp-dist/mnist/dist_mnist.py
+++ b/examples/tcp-dist/mnist/dist_mnist.py
@@ -67,7 +67,7 @@ class Net(nn.Module):
         x = F.relu(self.fc1(x))
         x = F.dropout(x, training=self.training)
         x = self.fc2(x)
-        return F.log_softmax(x)
+        return F.log_softmax(x, dim=1)
 
 
 def partition_dataset():
@@ -115,7 +115,7 @@ def run():
             optimizer.zero_grad()
             output = model(data)
             loss = F.nll_loss(output, target)
-            epoch_loss += loss.data[0]
+            epoch_loss += loss.item()
             loss.backward()
             average_gradients(model)
             optimizer.step()


### PR DESCRIPTION
Adding pytorch 0.4 as the base image for all examples

Fixes #69 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pytorch-operator/79)
<!-- Reviewable:end -->
