### PR TITLE
Adding v1beta1 binary to the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,6 @@ FROM debian:jessie
 
 COPY pytorch-operator /pytorch-operator
 COPY pytorch-operator.v2 /pytorch-operator.v2
+COPY pytorch-operator.v1beta1 /pytorch-operator.v1beta1
 
 ENTRYPOINT ["/pytorch-operator", "-alsologtostderr"]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -37,6 +37,8 @@ echo "Build pytorch operator v1alpha1 binary"
 go build github.com/kubeflow/pytorch-operator/cmd/pytorch-operator
 echo "Build pytorch operator v1alpha2 binary"
 go build github.com/kubeflow/pytorch-operator/cmd/pytorch-operator.v2
+echo "Build pytorch operator v1beta1 binary"
+go build github.com/kubeflow/pytorch-operator/cmd/pytorch-operator.v1beta1
 
 echo "Building PyTorch operator in gcloud"
 gcloud version


### PR DESCRIPTION
This PR adds v1beta1 binary to the pytorch docker image