### PR TITLE
Keeping default project as kubeflow-ci

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -7,7 +7,6 @@ workflows:
     job_types:
       - presubmit
     params:
-      project: "kubeflow-ci"
       registry: "gcr.io/kubeflow-ci"
   # The postsubmit run publishes the docker images to gcr.io/kubeflow-images-public
   - app_dir: kubeflow/pytorch-operator/test/workflows
@@ -16,5 +15,4 @@ workflows:
     job_types:
       - postsubmit
     params:
-      project: "kubeflow-images-public"
       registry: "gcr.io/kubeflow-images-public"


### PR DESCRIPTION
Default project is Kubeflow-ci for presubmit and post submit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pytorch-operator/106)
<!-- Reviewable:end -->
