### PR TITLE
Add master role label for PyTorchJob

### DIFF
--- a/pkg/controller.v1beta1/pytorch/controller.go
+++ b/pkg/controller.v1beta1/pytorch/controller.go
@@ -49,6 +49,7 @@ const (
 	replicaIndexLabel   = "pytorch-replica-index"
 	labelGroupName      = "group_name"
 	labelPyTorchJobName = "pytorch_job_name"
+	labelPyTorchJobRole = "pytorch_job_role"
 )
 
 var (

--- a/pkg/controller.v1beta1/pytorch/pod.go
+++ b/pkg/controller.v1beta1/pytorch/pod.go
@@ -58,17 +58,23 @@ func (pc *PyTorchController) reconcilePods(
 	}
 	replicas := int(*spec.Replicas)
 	restart := false
+	masterRole := false
 
 	initializePyTorchReplicaStatuses(job, rtype)
 
 	podSlices := getPodSlices(pods, replicas, logger)
 	for index, podSlice := range podSlices {
+		masterRole = false
 		if len(podSlice) > 1 {
 			logger.Warningf("We have too many pods for %s %d", rt, index)
 			// TODO(gaocegege): Kill some pods.
 		} else if len(podSlice) == 0 {
 			logger.Infof("Need to create new pod: %s-%d", rt, index)
-			err = pc.createNewPod(job, rtype, strconv.Itoa(index), spec)
+
+			if rtype == v1beta1.PyTorchReplicaTypeMaster {
+				masterRole = true
+			}
+			err = pc.createNewPod(job, rtype, strconv.Itoa(index), spec, masterRole)
 			if err != nil {
 				return err
 			}
@@ -125,7 +131,7 @@ func getPodSlices(pods []*v1.Pod, replicas int, logger *log.Entry) [][]*v1.Pod {
 }
 
 // createNewPod creates a new pod for the given index and type.
-func (pc *PyTorchController) createNewPod(job *v1beta1.PyTorchJob, rtype v1beta1.PyTorchReplicaType, index string, spec *common.ReplicaSpec) error {
+func (pc *PyTorchController) createNewPod(job *v1beta1.PyTorchJob, rtype v1beta1.PyTorchReplicaType, index string, spec *common.ReplicaSpec, masterRole bool) error {
 	rt := strings.ToLower(string(rtype))
 	jobKey, err := KeyFunc(job)
 	if err != nil {
@@ -146,6 +152,9 @@ func (pc *PyTorchController) createNewPod(job *v1beta1.PyTorchJob, rtype v1beta1
 	labels[replicaTypeLabel] = rt
 	labels[replicaIndexLabel] = index
 
+	if masterRole {
+		labels[labelPyTorchJobRole] = "master"
+	}
 	podTemplate := spec.Template.DeepCopy()
 	totalReplicas := getTotalReplicas(job)
 	// Set name for the template.

--- a/pkg/controller.v1beta1/pytorch/pod.go
+++ b/pkg/controller.v1beta1/pytorch/pod.go
@@ -71,6 +71,7 @@ func (pc *PyTorchController) reconcilePods(
 		} else if len(podSlice) == 0 {
 			logger.Infof("Need to create new pod: %s-%d", rt, index)
 
+			//Pytorch Job will have exactly one Master pod available
 			if rtype == v1beta1.PyTorchReplicaTypeMaster {
 				masterRole = true
 			}


### PR DESCRIPTION
New master role label is set in the pod which acts as master of the job. In katib, this label is useful to track the master who is responsible for logging.

Sets new label 'pytorch_job_role':'master' to the master pod 

This label is added for consistency with TFJob

Related: https://github.com/kubeflow/katib/issues/294

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pytorch-operator/116)
<!-- Reviewable:end -->
