### PR TITLE
Renaming labels to consistent format

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ kubectl create -f examples/mnist/v1beta1/pytorch_job_mnist_gloo.yaml
 You should now be able to see the created pods matching the specified number of replicas.
 
 ```
-kubectl get pods -l pytorch_job_name=pytorch-dist-mnist
+kubectl get pods -l pytorch-job-name=pytorch-dist-mnist
 ```
 Training should run for about 10 epochs and takes 5-10 minutes on a cpu cluster. Logs can be inspected to see its training progress. 
 
 ```
-PODNAME=$(kubectl get pods -l pytorch_job_name=pytorch-dist-mnist,task_index=0 -o name)
+PODNAME=$(kubectl get pods -l pytorch-job-name=pytorch-dist-mnist,task_index=0 -o name)
 kubectl logs -f ${PODNAME}
 ```
 ## Monitoring a PyTorch Job

--- a/pkg/common/util/v1beta1/testutil/util.go
+++ b/pkg/common/util/v1beta1/testutil/util.go
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	LabelGroupName      = "group_name"
-	LabelPyTorchJobName = "pytorch_job_name"
+	LabelGroupName      = "group-name"
+	LabelPyTorchJobName = "pytorch-job-name"
 )
 
 var (

--- a/pkg/common/util/v1beta2/testutil/util.go
+++ b/pkg/common/util/v1beta2/testutil/util.go
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	LabelGroupName      = "group_name"
-	LabelPyTorchJobName = "pytorch_job_name"
+	LabelGroupName      = "group-name"
+	LabelPyTorchJobName = "pytorch-job-name"
 )
 
 var (

--- a/pkg/controller.v1beta1/pytorch/controller.go
+++ b/pkg/controller.v1beta1/pytorch/controller.go
@@ -47,9 +47,9 @@ const (
 	// labels for pods and servers.
 	replicaTypeLabel    = "pytorch-replica-type"
 	replicaIndexLabel   = "pytorch-replica-index"
-	labelGroupName      = "group_name"
-	labelPyTorchJobName = "pytorch_job_name"
-	labelPyTorchJobRole = "pytorch_job_role"
+	labelGroupName      = "group-name"
+	labelPyTorchJobName = "pytorch-job-name"
+	labelPyTorchJobRole = "pytorch-job-role"
 )
 
 var (

--- a/pkg/controller.v1beta1/pytorch/controller_test.go
+++ b/pkg/controller.v1beta1/pytorch/controller_test.go
@@ -412,7 +412,7 @@ func TestSyncPdb(t *testing.T) {
 					MinAvailable: &minAvailable,
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"pytorch_job_name": "test-sync-pdb",
+							"pytorch-job-name": "test-sync-pdb",
 						},
 					},
 				},

--- a/pkg/controller.v1beta2/pytorch/controller.go
+++ b/pkg/controller.v1beta2/pytorch/controller.go
@@ -47,9 +47,9 @@ const (
 	// labels for pods and servers.
 	replicaTypeLabel    = "pytorch-replica-type"
 	replicaIndexLabel   = "pytorch-replica-index"
-	labelGroupName      = "group_name"
-	labelPyTorchJobName = "pytorch_job_name"
-	labelPyTorchJobRole = "pytorch_job_role"
+	labelGroupName      = "group-name"
+	labelPyTorchJobName = "pytorch-job-name"
+	labelPyTorchJobRole = "pytorch-job-role"
 )
 
 var (

--- a/pkg/controller.v1beta2/pytorch/controller_test.go
+++ b/pkg/controller.v1beta2/pytorch/controller_test.go
@@ -412,7 +412,7 @@ func TestSyncPdb(t *testing.T) {
 					MinAvailable: &minAvailable,
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"pytorch_job_name": "test-sync-pdb",
+							"pytorch-job-name": "test-sync-pdb",
 						},
 					},
 				},

--- a/test/e2e/v1beta1/cleanpolicy_all.go
+++ b/test/e2e/v1beta1/cleanpolicy_all.go
@@ -146,8 +146,8 @@ func run() (string, error) {
 	}
 
 	l := map[string]string{
-		"group_name":       v1beta1.GroupName,
-		"pytorch_job_name": strings.Replace(*name, "/", "-", -1),
+		"group-name":       v1beta1.GroupName,
+		"pytorch-job-name": strings.Replace(*name, "/", "-", -1),
 	}
 
 	labels := make([]string, 0, len(l))


### PR DESCRIPTION
Fixes: #140 

All labels are renamed to use hyphens instead of underscores.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pytorch-operator/146)
<!-- Reviewable:end -->
