### PR TITLE
Adding cleaner base image for operator builds 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 COPY pytorch-operator.v1beta1 /pytorch-operator.v1beta1
 COPY pytorch-operator.v1beta2 /pytorch-operator.v1beta2


### PR DESCRIPTION
Secure base image is kept same as in tf-operator 

Related: https://github.com/kubeflow/tf-operator/pull/962

Fixes: #152

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/pytorch-operator/153)
<!-- Reviewable:end -->
