### PR TITLE
Set start timestamp

### DIFF
--- a/pkg/controller.v1/pytorch/status.go
+++ b/pkg/controller.v1/pytorch/status.go
@@ -58,8 +58,8 @@ func (pc *PyTorchController) updateStatusSingle(job *pyv1.PyTorchJob, rtype pyv1
 
 	pylogger.LoggerForJob(job).Infof("PyTorchJob=%s, ReplicaType=%s expected=%d, running=%d, failed=%d",
 		job.Name, rtype, expected, running, failed)
-	// All workers are running, set StartTime.
-	if running == replicas && job.Status.StartTime == nil {
+	// Set StartTime.
+	if job.Status.StartTime == nil {
 		now := metav1.Now()
 		job.Status.StartTime = &now
 		// enqueue a sync to check if job past ActiveDeadlineSeconds

--- a/pkg/controller.v1beta2/pytorch/status.go
+++ b/pkg/controller.v1beta2/pytorch/status.go
@@ -58,8 +58,8 @@ func (pc *PyTorchController) updateStatusSingle(job *v1beta2.PyTorchJob, rtype v
 
 	pylogger.LoggerForJob(job).Infof("PyTorchJob=%s, ReplicaType=%s expected=%d, running=%d, failed=%d",
 		job.Name, rtype, expected, running, failed)
-	// All workers are running, set StartTime.
-	if running == replicas && job.Status.StartTime == nil {
+	// Set StartTime.
+	if job.Status.StartTime == nil {
 		now := metav1.Now()
 		job.Status.StartTime = &now
 		// enqueue a sync to check if job past ActiveDeadlineSeconds


### PR DESCRIPTION
Start timestamp is set when job is created.
Related: https://github.com/kubeflow/tf-operator/pull/1001