### PR TITLE
Adds developer guide and sample CRD for v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Overview
 
 This repository contains the specification and implementation of `PyTorchJob` custom resource definition. Using this custom resource, users can create and manage PyTorch jobs like other built-in resources in Kubernetes. See [CRD definition](https://github.com/kubeflow/kubeflow/blob/master/kubeflow/pytorch-job/pytorch-operator.libsonnet#L11)
-  
+
 ## Prerequisites
 
 - Kubernetes >= 1.8
@@ -34,7 +34,7 @@ You should now be able to see the created pods matching the specified number of 
 ```
 kubectl get pods -l pytorch-job-name=pytorch-dist-mnist-gloo
 ```
-Training should run for about 10 epochs and takes 5-10 minutes on a cpu cluster. Logs can be inspected to see its training progress. 
+Training should run for about 10 epochs and takes 5-10 minutes on a cpu cluster. Logs can be inspected to see its training progress.
 
 ```
 PODNAME=$(kubectl get pods -l pytorch-job-name=pytorch-dist-mnist-gloo,pytorch-replica-type=master -o name)
@@ -118,3 +118,7 @@ items:
         succeeded: 1
     startTime: 2019-01-11T00:57:22Z
 ```
+
+## Contributing
+
+Please refer to the [developer_guide](developer_guide.md).

--- a/developer_guide.md
+++ b/developer_guide.md
@@ -1,0 +1,79 @@
+# Developer Guide
+
+PyTorch-operator is currently at v1. The v1beta2 version will still be supported and is compatible with v1.
+
+## Building the operator
+
+```sh
+cd ${GOPATH}/src/github.com/kubeflow
+git clone git@github.com:kubeflow/pytorch-operator.git
+```
+
+Resolve dependencies (if you don't have dep install, check how to do it [here](https://github.com/golang/dep))
+
+Install dependencies
+
+```sh
+dep ensure
+```
+
+Build it
+
+```sh
+go install github.com/kubeflow/pytorch-operator/cmd/pytorch-operator.v1
+```
+
+## Running the Operator Locally
+
+Running the operator locally (as opposed to deploying it on a K8s cluster) is convenient for debugging/development.
+
+### Run a Kubernetes cluster
+
+First, you need to run a Kubernetes cluster locally. There are lots of choices:
+
+- [local-up-cluster.sh in Kubernetes](https://github.com/kubernetes/kubernetes/blob/master/hack/local-up-cluster.sh)
+- [minikube](https://github.com/kubernetes/minikube)
+
+`local-up-cluster.sh` runs a single-node Kubernetes cluster locally, but Minikube runs a single-node Kubernetes cluster inside a VM. It is all compilable with the controller, but the Kubernetes version should be `1.8` or above.
+
+Notice: If you use `local-up-cluster.sh`, please make sure that the kube-dns is up, see [kubernetes/kubernetes#47739](https://github.com/kubernetes/kubernetes/issues/47739) for more details.
+
+### Configure KUBECONFIG and KUBEFLOW_NAMESPACE
+
+We can configure the operator to run locally using the configuration available in your kubeconfig to communicate with
+a K8s cluster. Set your environment:
+
+```sh
+export KUBECONFIG=$(echo ~/.kube/config)
+export KUBEFLOW_NAMESPACE=$(your_namespace)
+```
+
+* KUBEFLOW_NAMESPACE is used when deployed on Kubernetes, we use this variable to create other resources (e.g. the resource lock) internal in the same namespace. It is optional, use `default` namespace if not set.
+
+### Create the PyTorch Operator CRD
+
+After the cluster is up, the PyTorch Operator CRD should be created on the cluster.
+
+```bash
+kubectl create -f ./examples/crd/crd-v1.yaml
+```
+
+### Run Operator
+
+Now we are ready to run operator locally:
+
+```sh
+pytorch-operator.v1
+```
+
+To verify local operator is working, create an example job and you should see jobs created by it.
+
+```sh
+cd ./examples/mnist
+docker build -f Dockerfile -t kubeflow/pytorch-dist-mnist-test:1.0 ./
+kubectl create -f ./v1/pytorch_job_mnist_gloo.yaml
+```
+
+## Go version
+
+On ubuntu the default go package appears to be gccgo-go which has problems see [issue](https://github.com/golang/go/issues/15429) golang-go package is also really old so install from golang tarballs instead.

--- a/examples/crd/crd-v1.yaml
+++ b/examples/crd/crd-v1.yaml
@@ -1,0 +1,52 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/deploy-manager: ksonnet
+    ksonnet.io/component: pytorch-operator
+  name: pytorchjobs.kubeflow.org
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[-1:].type
+    name: State
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  conversion:
+    strategy: None
+  group: kubeflow.org
+  names:
+    kind: PyTorchJob
+    listKind: PyTorchJobList
+    plural: pytorchjobs
+    singular: pytorchjob
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            pytorchReplicaSpecs:
+              properties:
+                Master:
+                  properties:
+                    replicas:
+                      maximum: 1
+                      minimum: 1
+                      type: integer
+                Worker:
+                  properties:
+                    replicas:
+                      minimum: 1
+                      type: integer
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  - name: v1beta2
+    served: true
+    storage: false


### PR DESCRIPTION
This PR adds a developer guide similar to the one in [tensorflow operator](https://github.com/kubeflow/tf-operator/blob/master/developer_guide.md).