### PR TITLE
Minor fix to add CoreV1 to scheme

### DIFF
--- a/cmd/pytorch-operator.v1/app/server.go
+++ b/cmd/pytorch-operator.v1/app/server.go
@@ -133,7 +133,7 @@ func Run(opt *options.ServerOption) error {
 
 	// Prepare event clients.
 	eventBroadcaster := record.NewBroadcaster()
-	if err = pyv1.AddToScheme(scheme.Scheme); err != nil {
+	if err = v1.AddToScheme(scheme.Scheme); err != nil {
 		return fmt.Errorf("coreV1 Add Scheme failed: %v", err)
 	}
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "pytorch-operator"})


### PR DESCRIPTION
CoreV1 scheme is added as in v1beta2 version https://github.com/kubeflow/pytorch-operator/blob/master/cmd/pytorch-operator.v1beta2/app/server.go#L127