### PR TITLE
feat: Support running although it is uesless

### DIFF
--- a/pkg/controller.v1/pytorch/job.go
+++ b/pkg/controller.v1/pytorch/job.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -153,8 +153,9 @@ func (pc *PyTorchController) deletePodsAndServices(job *pyv1.PyTorchJob, pods []
 		return nil
 	}
 
-	// Delete nothing when the cleanPodPolicy is None.
-	if *job.Spec.CleanPodPolicy == common.CleanPodPolicyNone {
+	// Delete nothing when the cleanPodPolicy is None or Running.
+	if *job.Spec.CleanPodPolicy == common.CleanPodPolicyNone ||
+		*job.Spec.CleanPodPolicy == common.CleanPodPolicyRunning {
 		return nil
 	}
 

--- a/pkg/controller.v1beta2/pytorch/job.go
+++ b/pkg/controller.v1beta2/pytorch/job.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -143,8 +143,9 @@ func (pc *PyTorchController) deletePodsAndServices(job *v1beta2.PyTorchJob, pods
 		return nil
 	}
 
-	// Delete nothing when the cleanPodPolicy is None.
-	if *job.Spec.CleanPodPolicy == common.CleanPodPolicyNone {
+	// Delete nothing when the cleanPodPolicy is None or Running.
+	if *job.Spec.CleanPodPolicy == common.CleanPodPolicyNone ||
+		*job.Spec.CleanPodPolicy == common.CleanPodPolicyRunning {
 		return nil
 	}
 


### PR DESCRIPTION
We are using common.CleanPodPolicy now in pytorchjob, and if users set the policy to running, we will delete all pods and services. I think the behaviour is not consistent with tfjob. In pytorchjob, maybe we could support running, which does not delete anything just like None, to be user-friendly.

WDYT @johnugeorge 

One of our users does not know we do not support running, and use it. Then he found that the pods are deleted although they are not running

Signed-off-by: Ce Gao <gaoce@caicloud.io>