### PR TITLE
Use multi-build to build pytorch-operator image

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -4,4 +4,4 @@
 .git
 .gitignore
 #!include:.gitignore
-vendor
+#vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ ADD . /go/src/github.com/kubeflow/pytorch-operator
 WORKDIR /go/src/github.com/kubeflow/pytorch-operator
 
 # Build pytorch operator v1beta2 binary
-RUN go build cmd/pytorch-operator.v1beta2
+RUN go build ./cmd/pytorch-operator.v1beta2
 # Build pytorch operator v1 binary
-RUN go build cmd/pytorch-operator.v1
+RUN go build ./cmd/pytorch-operator.v1
 
 FROM registry.access.redhat.com/ubi8/ubi:latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,17 @@
+FROM golang:1.12 AS build-image
+
+ADD . /go/src/github.com/kubeflow/pytorch-operator
+
+WORKDIR /go/src/github.com/kubeflow/pytorch-operator
+
+# Build pytorch operator v1beta2 binary
+RUN go build github.com/kubeflow/pytorch-operator/cmd/pytorch-operator.v1beta2
+# Build pytorch operator v1 binary
+RUN go build github.com/kubeflow/pytorch-operator/cmd/pytorch-operator.v1
+
 FROM registry.access.redhat.com/ubi8/ubi:latest
 
-COPY pytorch-operator.v1beta2 /pytorch-operator.v1beta2
-COPY pytorch-operator.v1 /pytorch-operator.v1
+COPY --from=build-image /go/src/github.com/kubeflow/pytorch-operator/pytorch-operator.v1beta2 /pytorch-operator.v1beta2
+COPY --from=build-image /go/src/github.com/kubeflow/pytorch-operator/pytorch-operator.v1 /pytorch-operator.v1
 
 ENTRYPOINT ["/pytorch-operator", "-alsologtostderr"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ ADD . /go/src/github.com/kubeflow/pytorch-operator
 WORKDIR /go/src/github.com/kubeflow/pytorch-operator
 
 # Build pytorch operator v1beta2 binary
-RUN go build github.com/kubeflow/pytorch-operator/cmd/pytorch-operator.v1beta2
+RUN go build cmd/pytorch-operator.v1beta2
 # Build pytorch operator v1 binary
-RUN go build github.com/kubeflow/pytorch-operator/cmd/pytorch-operator.v1
+RUN go build cmd/pytorch-operator.v1
 
 FROM registry.access.redhat.com/ubi8/ubi:latest
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -33,12 +33,6 @@ mkdir -p ${GOPATH}/src/github.com/${REPO_OWNER}
 ln -s ${PWD} ${GO_DIR}
 cd ${GO_DIR}
 
-echo "Build pytorch operator v1beta2 binary"
-go build github.com/kubeflow/pytorch-operator/cmd/pytorch-operator.v1beta2
-
-echo "Build pytorch operator v1 binary"
-go build github.com/kubeflow/pytorch-operator/cmd/pytorch-operator.v1
-
 echo "Building PyTorch operator in gcloud"
 gcloud version
 gcloud builds submit . --tag=${REGISTRY}/${REPO_NAME}:${VERSION} --project=${PROJECT}


### PR DESCRIPTION
Use multi-build to build pytorch-operator image.
See detail: #195 