### PR TITLE
Set pytorchjob defaults in test utils

### DIFF
--- a/pkg/common/util/v1/testutil/job.go
+++ b/pkg/common/util/v1/testutil/job.go
@@ -105,6 +105,7 @@ func NewPyTorchJob(worker int) *pyv1.PyTorchJob {
 			PyTorchReplicaSpecs: make(map[pyv1.PyTorchReplicaType]*common.ReplicaSpec),
 		},
 	}
+	pyv1.SetObjectDefaults_PyTorchJob(job)
 
 	if worker > 0 {
 		worker := int32(worker)

--- a/pkg/common/util/v1beta2/testutil/job.go
+++ b/pkg/common/util/v1beta2/testutil/job.go
@@ -105,6 +105,7 @@ func NewPyTorchJob(worker int) *v1beta2.PyTorchJob {
 			PyTorchReplicaSpecs: make(map[v1beta2.PyTorchReplicaType]*common.ReplicaSpec),
 		},
 	}
+	v1beta2.SetObjectDefaults_PyTorchJob(job)
 
 	if worker > 0 {
 		worker := int32(worker)


### PR DESCRIPTION
When creating a pytorchjob object for testing, the default values should
also be filled in using the same defaulter function in the scheme.