### PR TITLE
Add qps and burst options

### DIFF
--- a/cmd/pytorch-operator.v1/app/options/options.go
+++ b/cmd/pytorch-operator.v1/app/options/options.go
@@ -34,6 +34,12 @@ type ServerOption struct {
 	Namespace            string
 	MonitoringPort       int
 	ResyncPeriod         time.Duration
+	// QPS indicates the maximum QPS to the master from this client.
+	// If it's zero, the created RESTClient will use DefaultQPS: 5
+	QPS int
+	// Maximum burst for throttle.
+	// If it's zero, the created RESTClient will use DefaultBurst: 10.
+	Burst int
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -67,4 +73,7 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.IntVar(&s.MonitoringPort, "monitoring-port", 8443, `Endpoint port for displaying monitoring metrics`)
 
 	fs.DurationVar(&s.ResyncPeriod, "resyc-period", DefaultResyncPeriod, "Resync interval of the tf-operator")
+
+	fs.IntVar(&s.QPS, "qps", 5, "QPS indicates the maximum QPS to the master from this client.")
+	fs.IntVar(&s.Burst, "burst", 10, "Maximum burst for throttle.")
 }

--- a/cmd/pytorch-operator.v1/app/server.go
+++ b/cmd/pytorch-operator.v1/app/server.go
@@ -94,6 +94,10 @@ func Run(opt *options.ServerOption) error {
 		log.Fatalf("Error building kubeconfig: %s", err.Error())
 	}
 
+	// Set client qps and burst by opt.
+	kcfg.QPS = float32(opt.QPS)
+	kcfg.Burst = opt.Burst
+
 	// Create clients.
 	kubeClientSet, leaderElectionClientSet, pytorchJobClientSet, kubeBatchClientSet, err := createClientSets(kcfg)
 	if err != nil {

--- a/cmd/pytorch-operator.v1beta2/app/options/options.go
+++ b/cmd/pytorch-operator.v1beta2/app/options/options.go
@@ -29,6 +29,12 @@ type ServerOption struct {
 	JSONLogFormat        bool
 	EnableGangScheduling bool
 	Namespace            string
+	// QPS indicates the maximum QPS to the master from this client.
+	// If it's zero, the created RESTClient will use DefaultQPS: 5
+	QPS int
+	// Maximum burst for throttle.
+	// If it's zero, the created RESTClient will use DefaultBurst: 10.
+	Burst int
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -57,4 +63,7 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&s.JSONLogFormat, "json-log-format", true,
 		"Set true to use json style log format. Set false to use plaintext style log format")
 	fs.BoolVar(&s.EnableGangScheduling, "enable-gang-scheduling", false, "Set true to enable gang scheduling by kube-batch.")
+
+	fs.IntVar(&s.QPS, "qps", 5, "QPS indicates the maximum QPS to the master from this client.")
+	fs.IntVar(&s.Burst, "burst", 10, "Maximum burst for throttle.")
 }

--- a/cmd/pytorch-operator.v1beta2/app/server.go
+++ b/cmd/pytorch-operator.v1beta2/app/server.go
@@ -88,6 +88,10 @@ func Run(opt *options.ServerOption) error {
 		log.Fatalf("Error building kubeconfig: %s", err.Error())
 	}
 
+	// Set client qps and burst by opt.
+	kcfg.QPS = float32(opt.QPS)
+	kcfg.Burst = opt.Burst
+
 	// Create clients.
 	kubeClientSet, leaderElectionClientSet, pytorchJobClientSet, kubeBatchClientSet, err := createClientSets(kcfg)
 	if err != nil {


### PR DESCRIPTION
This PR improves the client performance when creating lots of jobs at the same time.
See: kubeflow/tf-operator#1063