### PR TITLE
Fix nslookup cannot work well in initContainerTemplate

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -8,7 +8,7 @@ import (
 
 var initContainerTemplate = `
 - name: init-pytorch
-  image: busybox:1.31.0
+  image: alpine:3.10
   imagePullPolicy: IfNotPresent
   command: ['sh', '-c', 'until nslookup {{.MasterAddr}}; do echo waiting for master; sleep 2; done;']`
 


### PR DESCRIPTION
PytorchJob workers' initContainer always try to check if master pod is up by `nslookup` command, however nslookup in default image `busybox:1.31.0` version seems too old that it cannot work well, its exit code is always 1 for ppc64le arch even it can parse master service dns, and for amd64, it cannot work steadily as below, when I change the image to `alpine:3.10`, both on amd64 and ppc64le, it works well

```
/ # nslookup katib-suggestion-hyperband
Server:         10.0.0.10
Address:        10.0.0.10:53

Name:   katib-suggestion-hyperband.kubeflow.svc.cluster.local
Address: 10.0.223.142

*** Can't find katib-suggestion-hyperband.svc.cluster.local: No answer
*** Can't find katib-suggestion-hyperband.cluster.local: No answer
*** Can't find katib-suggestion-hyperband.fyre.ibm.com: No answer
*** Can't find katib-suggestion-hyperband.kubeflow.svc.cluster.local: No answer
*** Can't find katib-suggestion-hyperband.svc.cluster.local: No answer
*** Can't find katib-suggestion-hyperband.cluster.local: No answer
*** Can't find katib-suggestion-hyperband.fyre.ibm.com: No answer

/ # echo $?
0
/ # nslookup katib-suggestion-hyperband
Server:         10.0.0.10
Address:        10.0.0.10:53

** server can't find katib-suggestion-hyperband.kubeflow.svc.cluster.local: NXDOMAIN

*** Can't find katib-suggestion-hyperband.svc.cluster.local: No answer
*** Can't find katib-suggestion-hyperband.cluster.local: No answer
*** Can't find katib-suggestion-hyperband.fyre.ibm.com: No answer
*** Can't find katib-suggestion-hyperband.kubeflow.svc.cluster.local: No answer
*** Can't find katib-suggestion-hyperband.svc.cluster.local: No answer
*** Can't find katib-suggestion-hyperband.cluster.local: No answer
*** Can't find katib-suggestion-hyperband.fyre.ibm.com: No answer

/ # echo $?
1
/ # nslookup katib-suggestion-hyperband
Server:         10.0.0.10
Address:        10.0.0.10:53

** server can't find katib-suggestion-hyperband.kubeflow.svc.cluster.local: NXDOMAIN

*** Can't find katib-suggestion-hyperband.svc.cluster.local: No answer
*** Can't find katib-suggestion-hyperband.cluster.local: No answer
*** Can't find katib-suggestion-hyperband.fyre.ibm.com: No answer
*** Can't find katib-suggestion-hyperband.kubeflow.svc.cluster.local: No answer
*** Can't find katib-suggestion-hyperband.svc.cluster.local: No answer
*** Can't find katib-suggestion-hyperband.cluster.local: No answer
*** Can't find katib-suggestion-hyperband.fyre.ibm.com: No answer

/ # echo $?
1
/ # nslookup katib-suggestion-hyperband
Server:         10.0.0.10
Address:        10.0.0.10:53

Name:   katib-suggestion-hyperband.kubeflow.svc.cluster.local
Address: 10.0.223.142

*** Can't find katib-suggestion-hyperband.svc.cluster.local: No answer
*** Can't find katib-suggestion-hyperband.cluster.local: No answer
*** Can't find katib-suggestion-hyperband.fyre.ibm.com: No answer
*** Can't find katib-suggestion-hyperband.kubeflow.svc.cluster.local: No answer
*** Can't find katib-suggestion-hyperband.svc.cluster.local: No answer
*** Can't find katib-suggestion-hyperband.cluster.local: No answer
*** Can't find katib-suggestion-hyperband.fyre.ibm.com: No answer

/ # echo $?
0
```