### PR TITLE
v1beta foldeer has been renamed to v1 so needs the path too

### DIFF
--- a/examples/mnist/README.md
+++ b/examples/mnist/README.md
@@ -21,5 +21,5 @@ NOTE: If you you are working on Power System, Dockerfile.ppc64le could be used.
 The below example uses the gloo backend.
 
 ```shell
-kubectl create -f ./v1beta1/pytorch_job_mnist_gloo.yaml
+kubectl create -f ./v1/pytorch_job_mnist_gloo.yaml
 ```


### PR DESCRIPTION
v1beta foldeer has been renamed to v1 so needs the path too:
new command:
kubectl create -f ./v1/pytorch_job_mnist_gloo.yaml

Inconsistent documentation