### PR TITLE
Added Pytorch Cuda Docker Image as the Image pytorch/pytorch:1.0-cuda10.0-cudnn7-runtime in not having cuda so cannot used GPU

### DIFF
--- a/examples/mnist/README.md
+++ b/examples/mnist/README.md
@@ -21,5 +21,5 @@ NOTE: If you you are working on Power System, Dockerfile.ppc64le could be used.
 The below example uses the gloo backend.
 
 ```shell
-kubectl create -f ./v1beta1/pytorch_job_mnist_gloo.yaml
+kubectl create -f ./v1/pytorch_job_mnist_gloo.yaml
 ```

--- a/pytorch_cuda_docker/Dockerfile
+++ b/pytorch_cuda_docker/Dockerfile
@@ -1,0 +1,54 @@
+FROM nvidia/cuda:9.2-base-ubuntu16.04
+
+# Install some basic utilities
+RUN apt-get update && apt-get install -y \
+    curl \
+    ca-certificates \
+    sudo \
+    git \
+    bzip2 \
+    libx11-6 \
+ && rm -rf /var/lib/apt/lists/*
+
+# Create a working directory
+RUN mkdir /app
+WORKDIR /var
+
+# Create a non-root user and switch to it
+
+
+# All users can use /home/user as their home directory
+ENV HOME=/var
+RUN chmod 777 /var
+
+# Install Miniconda
+RUN curl -so ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh \
+ && chmod +x ~/miniconda.sh \
+ && ~/miniconda.sh -b -p ~/miniconda \
+ && rm ~/miniconda.sh
+ENV PATH=/var/miniconda/bin:$PATH
+ENV CONDA_AUTO_UPDATE_CONDA=false
+
+# Create a Python 3.6 environment
+RUN /var/miniconda/bin/conda create -y --name py36 python=3.6.9 \
+ && /var/miniconda/bin/conda clean -ya
+ENV CONDA_DEFAULT_ENV=py36
+ENV CONDA_PREFIX=/var/miniconda/envs/$CONDA_DEFAULT_ENV
+ENV PATH=$CONDA_PREFIX/bin:$PATH
+RUN /var/miniconda/bin/conda install conda-build=3.18.9=py36_3 \
+ && /var/miniconda/bin/conda clean -ya
+
+# CUDA 9.2-specific steps
+RUN conda install -y -c pytorch \
+    cudatoolkit=9.2 \
+    "pytorch=1.2.0=py3.6_cuda9.2.148_cudnn7.6.2_0" \
+    "torchvision=0.4.0=py36_cu92" \
+ && conda clean -ya
+
+# Install HDF5 Python bindings
+RUN conda install -y h5py=2.8.0 \
+ && conda clean -ya
+RUN pip install h5py-cache==1.0
+
+# Install Torchnet, a high-level framework for PyTorch
+RUN pip install torchnet==0.0.4


### PR DESCRIPTION
Added Pytorch Cuda Docker Image as the Image pytorch/pytorch:1.0-cuda10.0-cudnn7-runtime in not having cuda.So the examples/mnist.py is not using GPU.The issue is with the pytorch image .The new docker image i supplied is having the cuda dlevel and runtime environment which i tested and working like a breeze on GPU.
The priginal mnist.py which was taking 10 -12 minutes on my double xeon 2670 is taking roughly 1 minute toi get completed using my Titan XP pascal series GPU.

This is the fix to the issue number #245