### PR TITLE
SDK supports getting PyTorchJob training process or logs

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -44,6 +44,8 @@ Class | Method | Description
 [PyTorchJobClient](docs/PyTorchJobClient.md)  | [get_job_status](docs/PyTorchJobClient.md#get_job_status) | Get the PyTorchJob status|
 [PyTorchJobClient](docs/PyTorchJobClient.md)  | [is_job_running](docs/PyTorchJobClient.md#is_job_running) | Check if the PyTorchJob running |
 [PyTorchJobClient](docs/PyTorchJobClient.md)  | [is_job_succeeded](docs/PyTorchJobClient.md#is_job_succeeded) | Check if the PyTorchJob Succeeded |
+[PyTorchJobClient](docs/PyTorchJobClient.md) | [get_pod_names](docs/PyTorchJobClient.md#get_pod_names) | Get pod names of PyTorchJob |
+[PyTorchJobClient](docs/PyTorchJobClient.md)| [get_logs](docs/PyTorchJobClient.md#get_logs) | Get training logs of the PyTorchJob |
 
 ## Documentation For Models
 

--- a/sdk/python/docs/PyTorchJobClient.md
+++ b/sdk/python/docs/PyTorchJobClient.md
@@ -25,6 +25,8 @@ PyTorchJobClient | [wait_for_condition](#wait_for_condition) | Waits until any o
 PyTorchJobClient | [get_job_status](#get_job_status) | Get the PyTorchJob status|
 PyTorchJobClient | [is_job_running](#is_job_running) | Check if the PyTorchJob running |
 PyTorchJobClient | [is_job_succeeded](#is_job_succeeded) | Check if the PyTorchJob Succeeded |
+PyTorchJobClient | [get_pod_names](#get_pod_names) | Get pod names of PyTorchJob |
+PyTorchJobClient | [get_logs](#get_logs) | Get training logs of the PyTorchJob |
 
 ## create
 > create(pytorchjob, namespace=None)
@@ -100,7 +102,7 @@ namespace | str | Namespace for pytorchjob deploying to. If the `namespace` is n
 object
 
 ## get
-> get(name=None, namespace=None, watch=False, timeout_seconds=600))
+> get(name=None, namespace=None, watch=False, timeout_seconds=600)
 
 Get the created pytorchjob in the specified namespace
 
@@ -324,3 +326,57 @@ namespace | str | The pytorchjob's namespace. Defaults to current or default nam
 
 ### Return type
 Bool
+
+## get_pod_names
+> get_pod_names(name, namespace=None, master=False, replica_type=None, replica_index=None)
+
+Get pod names of the PyTorchJob.
+
+### Example
+
+```python
+from kubeflow.pytorchjob import PyTorchJobClient
+
+pytorchjob_client = PyTorchJobClient()
+pytorchjob_client.get_pod_names('mnist', namespace='kubeflow')
+```
+
+### Parameters
+Name | Type |  Description | Notes
+------------ | ------------- | ------------- | -------------
+name  | str | The PyTorchJob name.| |
+namespace | str | The pytorchjob's namespace. Defaults to current or default namespace.| Optional |
+master  | bool | Only get pod with label 'job-role: master' pod if True. | |
+replica_type | str | User can specify one of 'master, worker' to only get one type pods. By default get all type pods.| |
+replica_index | str | User can specfy replica index to get one pod of the PyTorchJob. | |
+
+### Return type
+Set
+
+
+## get_logs
+> get_logs(name, namespace=None, master=True, replica_type=None, replica_index=None, follow=False)
+
+Get training logs of the PyTorchJob. By default only get the logs of Pod that has labels 'job-role: master', to get all pods logs, specfy the `master=False`.
+
+### Example
+
+```python
+from kubeflow.pytorchjob import PyTorchJobClient
+
+pytorchjob_client = PyTorchJobClient()
+pytorchjob_client.get_logs('mnist', namespace='kubeflow')
+```
+
+### Parameters
+Name | Type |  Description | Notes
+------------ | ------------- | ------------- | -------------
+name  | str | The PyTorchJob name.| |
+namespace | str | The pytorchjob's namespace. Defaults to current or default namespace.| Optional |
+master  | bool | Only get pod with label 'job-role: master' pod if True. | |
+replica_type  | str | User can specify one of 'master, worker' to only get one type pods. By default get all type pods.| |
+replica_index | str | User can specfy replica index to get one pod of the PyTorchJob. | |
+follow | bool | Follow the log stream of the pod. Defaults to false. | |
+
+### Return type
+Str

--- a/sdk/python/examples/kubeflow-pytorchjob-sdk.ipynb
+++ b/sdk/python/examples/kubeflow-pytorchjob-sdk.ipynb
@@ -127,13 +127,13 @@
       "text/plain": [
        "{'apiVersion': 'kubeflow.org/v1',\n",
        " 'kind': 'PyTorchJob',\n",
-       " 'metadata': {'creationTimestamp': '2020-01-02T09:37:48Z',\n",
+       " 'metadata': {'creationTimestamp': '2020-01-14T09:21:44Z',\n",
        "  'generation': 1,\n",
        "  'name': 'pytorch-dist-mnist-gloo',\n",
        "  'namespace': 'default',\n",
-       "  'resourceVersion': '21102420',\n",
+       "  'resourceVersion': '949015',\n",
        "  'selfLink': '/apis/kubeflow.org/v1/namespaces/default/pytorchjobs/pytorch-dist-mnist-gloo',\n",
-       "  'uid': '89b3f13c-2d43-11ea-8c04-00000a1001ee'},\n",
+       "  'uid': '47f9dc9a-36af-11ea-beb5-00163e01f7d2'},\n",
        " 'spec': {'cleanPodPolicy': 'None',\n",
        "  'pytorchReplicaSpecs': {'Master': {'replicas': 1,\n",
        "    'restartPolicy': 'OnFailure',\n",
@@ -153,8 +153,8 @@
     }
    ],
    "source": [
-    "pytorch_client = PyTorchJobClient()\n",
-    "pytorch_client.create(pytorchjob)"
+    "pytorchjob_client = PyTorchJobClient()\n",
+    "pytorchjob_client.create(pytorchjob)"
    ]
   },
   {
@@ -174,13 +174,13 @@
       "text/plain": [
        "{'apiVersion': 'kubeflow.org/v1',\n",
        " 'kind': 'PyTorchJob',\n",
-       " 'metadata': {'creationTimestamp': '2020-01-02T09:37:48Z',\n",
+       " 'metadata': {'creationTimestamp': '2020-01-14T09:21:44Z',\n",
        "  'generation': 1,\n",
        "  'name': 'pytorch-dist-mnist-gloo',\n",
        "  'namespace': 'default',\n",
-       "  'resourceVersion': '21102446',\n",
+       "  'resourceVersion': '949030',\n",
        "  'selfLink': '/apis/kubeflow.org/v1/namespaces/default/pytorchjobs/pytorch-dist-mnist-gloo',\n",
-       "  'uid': '89b3f13c-2d43-11ea-8c04-00000a1001ee'},\n",
+       "  'uid': '47f9dc9a-36af-11ea-beb5-00163e01f7d2'},\n",
        " 'spec': {'cleanPodPolicy': 'None',\n",
        "  'pytorchReplicaSpecs': {'Master': {'replicas': 1,\n",
        "    'restartPolicy': 'OnFailure',\n",
@@ -192,14 +192,14 @@
        "    'template': {'spec': {'containers': [{'args': ['--backend', 'gloo'],\n",
        "        'image': 'gcr.io/kubeflow-ci/pytorch-dist-mnist-test:v1.0',\n",
        "        'name': 'pytorch'}]}}}}},\n",
-       " 'status': {'conditions': [{'lastTransitionTime': '2020-01-02T09:37:48Z',\n",
-       "    'lastUpdateTime': '2020-01-02T09:37:48Z',\n",
+       " 'status': {'conditions': [{'lastTransitionTime': '2020-01-14T09:21:44Z',\n",
+       "    'lastUpdateTime': '2020-01-14T09:21:44Z',\n",
        "    'message': 'PyTorchJob pytorch-dist-mnist-gloo is created.',\n",
        "    'reason': 'PyTorchJobCreated',\n",
        "    'status': 'True',\n",
        "    'type': 'Created'}],\n",
        "  'replicaStatuses': {'Master': {}, 'Worker': {}},\n",
-       "  'startTime': '2020-01-02T09:37:49Z'}}"
+       "  'startTime': '2020-01-14T09:21:44Z'}}"
       ]
      },
      "execution_count": 5,
@@ -208,7 +208,7 @@
     }
    ],
    "source": [
-    "pytorch_client.get('pytorch-dist-mnist-gloo')"
+    "pytorchjob_client.get('pytorch-dist-mnist-gloo')"
    ]
   },
   {
@@ -235,7 +235,7 @@
     }
    ],
    "source": [
-    "pytorch_client.get_job_status('pytorch-dist-mnist-gloo', namespace=namespace)"
+    "pytorchjob_client.get_job_status('pytorch-dist-mnist-gloo', namespace=namespace)"
    ]
   },
   {
@@ -255,19 +255,16 @@
      "output_type": "stream",
      "text": [
       "NAME                           STATE                TIME                          \n",
-      "pytorch-dist-mnist-gloo        Created              2020-01-02T09:37:48Z          \n",
-      "pytorch-dist-mnist-gloo        Running              2020-01-02T09:37:58Z          \n",
-      "pytorch-dist-mnist-gloo        Running              2020-01-02T09:37:58Z          \n",
-      "pytorch-dist-mnist-gloo        Running              2020-01-02T09:37:58Z          \n",
-      "pytorch-dist-mnist-gloo        Running              2020-01-02T09:37:58Z          \n",
-      "pytorch-dist-mnist-gloo        Running              2020-01-02T09:37:58Z          \n",
-      "pytorch-dist-mnist-gloo        Running              2020-01-02T09:37:58Z          \n",
-      "pytorch-dist-mnist-gloo        Succeeded            2020-01-02T09:42:47Z          \n"
+      "pytorch-dist-mnist-gloo        Created              2020-01-14T09:21:44Z          \n",
+      "pytorch-dist-mnist-gloo        Running              2020-01-14T09:23:45Z          \n",
+      "pytorch-dist-mnist-gloo        Running              2020-01-14T09:23:45Z          \n",
+      "pytorch-dist-mnist-gloo        Running              2020-01-14T09:23:45Z          \n",
+      "pytorch-dist-mnist-gloo        Succeeded            2020-01-14T09:28:31Z          \n"
      ]
     }
    ],
    "source": [
-    "pytorch_client.wait_for_job('pytorch-dist-mnist-gloo', namespace=namespace, watch=True)"
+    "pytorchjob_client.wait_for_job('pytorch-dist-mnist-gloo', namespace=namespace, watch=True)"
    ]
   },
   {
@@ -294,7 +291,136 @@
     }
    ],
    "source": [
-    "pytorch_client.is_job_succeeded('pytorch-dist-mnist-gloo', namespace=namespace)"
+    "pytorchjob_client.is_job_succeeded('pytorch-dist-mnist-gloo', namespace=namespace)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get the PyTorchJob training logs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The logs of Pod pytorch-dist-mnist-gloo-master-0:\n",
+      " Using distributed PyTorch with gloo backend\n",
+      "Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz\n",
+      "Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz\n",
+      "Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz\n",
+      "Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz\n",
+      "Processing...\n",
+      "Done!\n",
+      "Train Epoch: 1 [0/60000 (0%)]\tloss=2.3000\n",
+      "Train Epoch: 1 [640/60000 (1%)]\tloss=2.2135\n",
+      "Train Epoch: 1 [1280/60000 (2%)]\tloss=2.1704\n",
+      "Train Epoch: 1 [1920/60000 (3%)]\tloss=2.0766\n",
+      "Train Epoch: 1 [2560/60000 (4%)]\tloss=1.8679\n",
+      "Train Epoch: 1 [3200/60000 (5%)]\tloss=1.4135\n",
+      "Train Epoch: 1 [3840/60000 (6%)]\tloss=1.0003\n",
+      "Train Epoch: 1 [4480/60000 (7%)]\tloss=0.7762\n",
+      "Train Epoch: 1 [5120/60000 (9%)]\tloss=0.4598\n",
+      "Train Epoch: 1 [5760/60000 (10%)]\tloss=0.4860\n",
+      "Train Epoch: 1 [6400/60000 (11%)]\tloss=0.4389\n",
+      "Train Epoch: 1 [7040/60000 (12%)]\tloss=0.4084\n",
+      "Train Epoch: 1 [7680/60000 (13%)]\tloss=0.4602\n",
+      "Train Epoch: 1 [8320/60000 (14%)]\tloss=0.4289\n",
+      "Train Epoch: 1 [8960/60000 (15%)]\tloss=0.3990\n",
+      "Train Epoch: 1 [9600/60000 (16%)]\tloss=0.3850\n",
+      "Train Epoch: 1 [10240/60000 (17%)]\tloss=0.2985\n",
+      "Train Epoch: 1 [10880/60000 (18%)]\tloss=0.5031\n",
+      "Train Epoch: 1 [11520/60000 (19%)]\tloss=0.5235\n",
+      "Train Epoch: 1 [12160/60000 (20%)]\tloss=0.3379\n",
+      "Train Epoch: 1 [12800/60000 (21%)]\tloss=0.3667\n",
+      "Train Epoch: 1 [13440/60000 (22%)]\tloss=0.4503\n",
+      "Train Epoch: 1 [14080/60000 (23%)]\tloss=0.3043\n",
+      "Train Epoch: 1 [14720/60000 (25%)]\tloss=0.3589\n",
+      "Train Epoch: 1 [15360/60000 (26%)]\tloss=0.3320\n",
+      "Train Epoch: 1 [16000/60000 (27%)]\tloss=0.4406\n",
+      "Train Epoch: 1 [16640/60000 (28%)]\tloss=0.3641\n",
+      "Train Epoch: 1 [17280/60000 (29%)]\tloss=0.3170\n",
+      "Train Epoch: 1 [17920/60000 (30%)]\tloss=0.2014\n",
+      "Train Epoch: 1 [18560/60000 (31%)]\tloss=0.4985\n",
+      "Train Epoch: 1 [19200/60000 (32%)]\tloss=0.3264\n",
+      "Train Epoch: 1 [19840/60000 (33%)]\tloss=0.1198\n",
+      "Train Epoch: 1 [20480/60000 (34%)]\tloss=0.1904\n",
+      "Train Epoch: 1 [21120/60000 (35%)]\tloss=0.1424\n",
+      "Train Epoch: 1 [21760/60000 (36%)]\tloss=0.3143\n",
+      "Train Epoch: 1 [22400/60000 (37%)]\tloss=0.1494\n",
+      "Train Epoch: 1 [23040/60000 (38%)]\tloss=0.2901\n",
+      "Train Epoch: 1 [23680/60000 (39%)]\tloss=0.4670\n",
+      "Train Epoch: 1 [24320/60000 (41%)]\tloss=0.2151\n",
+      "Train Epoch: 1 [24960/60000 (42%)]\tloss=0.1521\n",
+      "Train Epoch: 1 [25600/60000 (43%)]\tloss=0.2240\n",
+      "Train Epoch: 1 [26240/60000 (44%)]\tloss=0.2629\n",
+      "Train Epoch: 1 [26880/60000 (45%)]\tloss=0.2330\n",
+      "Train Epoch: 1 [27520/60000 (46%)]\tloss=0.2630\n",
+      "Train Epoch: 1 [28160/60000 (47%)]\tloss=0.2126\n",
+      "Train Epoch: 1 [28800/60000 (48%)]\tloss=0.1327\n",
+      "Train Epoch: 1 [29440/60000 (49%)]\tloss=0.2789\n",
+      "Train Epoch: 1 [30080/60000 (50%)]\tloss=0.0947\n",
+      "Train Epoch: 1 [30720/60000 (51%)]\tloss=0.1280\n",
+      "Train Epoch: 1 [31360/60000 (52%)]\tloss=0.2458\n",
+      "Train Epoch: 1 [32000/60000 (53%)]\tloss=0.3394\n",
+      "Train Epoch: 1 [32640/60000 (54%)]\tloss=0.1527\n",
+      "Train Epoch: 1 [33280/60000 (55%)]\tloss=0.0901\n",
+      "Train Epoch: 1 [33920/60000 (57%)]\tloss=0.1451\n",
+      "Train Epoch: 1 [34560/60000 (58%)]\tloss=0.1994\n",
+      "Train Epoch: 1 [35200/60000 (59%)]\tloss=0.2171\n",
+      "Train Epoch: 1 [35840/60000 (60%)]\tloss=0.0633\n",
+      "Train Epoch: 1 [36480/60000 (61%)]\tloss=0.1369\n",
+      "Train Epoch: 1 [37120/60000 (62%)]\tloss=0.1160\n",
+      "Train Epoch: 1 [37760/60000 (63%)]\tloss=0.2355\n",
+      "Train Epoch: 1 [38400/60000 (64%)]\tloss=0.0634\n",
+      "Train Epoch: 1 [39040/60000 (65%)]\tloss=0.1062\n",
+      "Train Epoch: 1 [39680/60000 (66%)]\tloss=0.1608\n",
+      "Train Epoch: 1 [40320/60000 (67%)]\tloss=0.1101\n",
+      "Train Epoch: 1 [40960/60000 (68%)]\tloss=0.1775\n",
+      "Train Epoch: 1 [41600/60000 (69%)]\tloss=0.2285\n",
+      "Train Epoch: 1 [42240/60000 (70%)]\tloss=0.0737\n",
+      "Train Epoch: 1 [42880/60000 (71%)]\tloss=0.1562\n",
+      "Train Epoch: 1 [43520/60000 (72%)]\tloss=0.2775\n",
+      "Train Epoch: 1 [44160/60000 (74%)]\tloss=0.1418\n",
+      "Train Epoch: 1 [44800/60000 (75%)]\tloss=0.1163\n",
+      "Train Epoch: 1 [45440/60000 (76%)]\tloss=0.1221\n",
+      "Train Epoch: 1 [46080/60000 (77%)]\tloss=0.0768\n",
+      "Train Epoch: 1 [46720/60000 (78%)]\tloss=0.1950\n",
+      "Train Epoch: 1 [47360/60000 (79%)]\tloss=0.0706\n",
+      "Train Epoch: 1 [48000/60000 (80%)]\tloss=0.2091\n",
+      "Train Epoch: 1 [48640/60000 (81%)]\tloss=0.1380\n",
+      "Train Epoch: 1 [49280/60000 (82%)]\tloss=0.0950\n",
+      "Train Epoch: 1 [49920/60000 (83%)]\tloss=0.1070\n",
+      "Train Epoch: 1 [50560/60000 (84%)]\tloss=0.1194\n",
+      "Train Epoch: 1 [51200/60000 (85%)]\tloss=0.1447\n",
+      "Train Epoch: 1 [51840/60000 (86%)]\tloss=0.0662\n",
+      "Train Epoch: 1 [52480/60000 (87%)]\tloss=0.0239\n",
+      "Train Epoch: 1 [53120/60000 (88%)]\tloss=0.2622\n",
+      "Train Epoch: 1 [53760/60000 (90%)]\tloss=0.0928\n",
+      "Train Epoch: 1 [54400/60000 (91%)]\tloss=0.1297\n",
+      "Train Epoch: 1 [55040/60000 (92%)]\tloss=0.1907\n",
+      "Train Epoch: 1 [55680/60000 (93%)]\tloss=0.0347\n",
+      "Train Epoch: 1 [56320/60000 (94%)]\tloss=0.0354\n",
+      "Train Epoch: 1 [56960/60000 (95%)]\tloss=0.0770\n",
+      "Train Epoch: 1 [57600/60000 (96%)]\tloss=0.1175\n",
+      "Train Epoch: 1 [58240/60000 (97%)]\tloss=0.1919\n",
+      "Train Epoch: 1 [58880/60000 (98%)]\tloss=0.2053\n",
+      "Train Epoch: 1 [59520/60000 (99%)]\tloss=0.0639\n",
+      "\n",
+      "accuracy=0.9664\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "pytorchjob_client.get_logs('pytorch-dist-mnist-gloo', namespace=namespace)"
    ]
   },
   {
@@ -306,7 +432,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -319,16 +445,16 @@
        " 'details': {'name': 'pytorch-dist-mnist-gloo',\n",
        "  'group': 'kubeflow.org',\n",
        "  'kind': 'pytorchjobs',\n",
-       "  'uid': '89b3f13c-2d43-11ea-8c04-00000a1001ee'}}"
+       "  'uid': '47f9dc9a-36af-11ea-beb5-00163e01f7d2'}}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "pytorch_client.delete('pytorch-dist-mnist-gloo')"
+    "pytorchjob_client.delete('pytorch-dist-mnist-gloo')"
    ]
   },
   {
@@ -355,7 +481,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/sdk/python/kubeflow/pytorchjob/api/py_torch_job_client.py
+++ b/sdk/python/kubeflow/pytorchjob/api/py_torch_job_client.py
@@ -14,6 +14,7 @@
 
 import multiprocessing
 import time
+import logging
 
 from kubernetes import client, config
 
@@ -21,6 +22,9 @@ from kubeflow.pytorchjob.constants import constants
 from kubeflow.pytorchjob.utils import utils
 
 from .py_torch_job_watch import watch as pytorchjob_watch
+
+logging.basicConfig(format='%(message)s')
+logging.getLogger().setLevel(logging.INFO)
 
 class PyTorchJobClient(object):
 
@@ -42,7 +46,8 @@ class PyTorchJobClient(object):
     else:
       config.load_incluster_config()
 
-    self.api_instance = client.CustomObjectsApi()
+    self.custom_api = client.CustomObjectsApi()
+    self.core_api = client.CoreV1Api()
 
 
   def create(self, pytorchjob, namespace=None):
@@ -57,7 +62,7 @@ class PyTorchJobClient(object):
       namespace = utils.set_pytorchjob_namespace(pytorchjob)
 
     try:
-      outputs = self.api_instance.create_namespaced_custom_object(
+      outputs = self.custom_api.create_namespaced_custom_object(
         constants.PYTORCHJOB_GROUP,
         constants.PYTORCHJOB_VERSION,
         namespace,
@@ -89,7 +94,7 @@ class PyTorchJobClient(object):
           namespace=namespace,
           timeout_seconds=timeout_seconds)
       else:
-        thread = self.api_instance.get_namespaced_custom_object(
+        thread = self.custom_api.get_namespaced_custom_object(
           constants.PYTORCHJOB_GROUP,
           constants.PYTORCHJOB_VERSION,
           namespace,
@@ -117,7 +122,7 @@ class PyTorchJobClient(object):
             namespace=namespace,
             timeout_seconds=timeout_seconds)
       else:
-        thread = self.api_instance.list_namespaced_custom_object(
+        thread = self.custom_api.list_namespaced_custom_object(
           constants.PYTORCHJOB_GROUP,
           constants.PYTORCHJOB_VERSION,
           namespace,
@@ -153,7 +158,7 @@ class PyTorchJobClient(object):
       namespace = utils.set_pytorchjob_namespace(pytorchjob)
 
     try:
-      outputs = self.api_instance.patch_namespaced_custom_object(
+      outputs = self.custom_api.patch_namespaced_custom_object(
         constants.PYTORCHJOB_GROUP,
         constants.PYTORCHJOB_VERSION,
         namespace,
@@ -179,7 +184,7 @@ class PyTorchJobClient(object):
       namespace = utils.get_default_target_namespace()
 
     try:
-      return self.api_instance.delete_namespaced_custom_object(
+      return self.custom_api.delete_namespaced_custom_object(
         constants.PYTORCHJOB_GROUP,
         constants.PYTORCHJOB_VERSION,
         namespace,
@@ -309,3 +314,80 @@ class PyTorchJobClient(object):
     """
     pytorchjob_status = self.get_job_status(name, namespace=namespace)
     return pytorchjob_status.lower() == "succeeded"
+
+
+  def get_pod_names(self, name, namespace=None, master=False, #pylint: disable=inconsistent-return-statements
+                    replica_type=None, replica_index=None):
+    """
+    Get pod names of PyTorchJob.
+    :param name: PyTorchJob name
+    :param namespace: defaults to current or default namespace.
+    :param master: Only get pod with label 'job-role: master' pod if True.
+    :param replica_type: User can specify one of 'master, worker' to only get one type pods.
+           By default get all type pods.
+    :param replica_index: User can specfy replica index to get one pod of PyTorchJob.
+    :return: set: pods name
+    """
+
+    if namespace is None:
+      namespace = utils.get_default_target_namespace()
+
+    labels = utils.get_labels(name, master=master,
+                              replica_type=replica_type,
+                              replica_index=replica_index)
+
+    try:
+      resp = self.core_api.list_namespaced_pod(
+        namespace, label_selector=utils.to_selector(labels))
+    except client.rest.ApiException as e:
+      raise RuntimeError(
+        "Exception when calling CoreV1Api->read_namespaced_pod_log: %s\n" % e)
+
+    pod_names = []
+    for pod in resp.items:
+      if pod.metadata and pod.metadata.name:
+        pod_names.append(pod.metadata.name)
+
+    if not pod_names:
+      logging.warning("Not found Pods of the PyTorchJob %s with the labels %s.", name, labels)
+    else:
+      return set(pod_names)
+
+
+  def get_logs(self, name, namespace=None, master=True,
+               replica_type=None, replica_index=None,
+               follow=False):
+    """
+    Get training logs of the PyTorchJob.
+    By default only get the logs of Pod that has labels 'job-role: master'.
+    :param name: PyTorchJob name
+    :param namespace: defaults to current or default namespace.
+    :param master: By default get pod with label 'job-role: master' pod if True.
+                   If need to get more Pod Logs, set False.
+    :param replica_type: User can specify one of 'master, worker' to only get one type pods.
+           By default get all type pods.
+    :param replica_index: User can specfy replica index to get one pod of PyTorchJob.
+    :param follow: Follow the log stream of the pod. Defaults to false.
+    :return: str: pods logs
+    """
+
+    if namespace is None:
+      namespace = utils.get_default_target_namespace()
+
+    pod_names = self.get_pod_names(name, namespace=namespace,
+                                   master=master,
+                                   replica_type=replica_type,
+                                   replica_index=replica_index)
+
+    if pod_names:
+      for pod in pod_names:
+        try:
+          pod_logs = self.core_api.read_namespaced_pod_log(
+            pod, namespace, follow=follow)
+          logging.info("The logs of Pod %s:\n %s", pod, pod_logs)
+        except client.rest.ApiException as e:
+          raise RuntimeError(
+            "Exception when calling CoreV1Api->read_namespaced_pod_log: %s\n" % e)
+    else:
+      raise RuntimeError("Not found Pods of the PyTorchJob {} "
+                         "in namespace {}".format(name, namespace))

--- a/sdk/python/kubeflow/pytorchjob/constants/constants.py
+++ b/sdk/python/kubeflow/pytorchjob/constants/constants.py
@@ -24,3 +24,11 @@ PYTORCH_LOGLEVEL = os.environ.get('PYTORCHJOB_LOGLEVEL', 'INFO').upper()
 
 # How long to wait in seconds for requests to the ApiServer
 APISERVER_TIMEOUT = 120
+
+#PyTorchJob Labels Name
+PYTORCHJOB_CONTROLLER_LABEL = 'controller-name'
+PYTORCHJOB_GROUP_LABEL = 'group-name'
+PYTORCHJOB_NAME_LABEL = 'pytorch-job-name'
+PYTORCHJOB_TYPE_LABEL = 'pytorch-replica-type'
+PYTORCHJOB_INDEX_LABEL = 'pytorch-replica-index'
+PYTORCHJOB_ROLE_LABEL = 'job-role'

--- a/sdk/python/kubeflow/pytorchjob/utils/utils.py
+++ b/sdk/python/kubeflow/pytorchjob/utils/utils.py
@@ -14,6 +14,8 @@
 
 import os
 
+from kubeflow.pytorchjob.constants import constants
+
 def is_running_in_k8s():
   return os.path.isdir('/var/run/secrets/kubernetes.io/')
 
@@ -33,3 +35,41 @@ def set_pytorchjob_namespace(pytorchjob):
   pytorchjob_namespace = pytorchjob.metadata.namespace
   namespace = pytorchjob_namespace or get_default_target_namespace()
   return namespace
+
+
+def get_labels(name, master=False, replica_type=None, replica_index=None):
+  """
+  Get labels according to speficed flags.
+  :param name: PyTorchJob name
+  :param master: if need include label 'job-role: master'.
+  :param replica_type: User can specify one of 'worker, ps, chief to only' get one type pods.
+  :param replica_index: Can specfy replica index to get one pod of PyTorchJob.
+  :return: Dict: Labels
+  """
+  labels = {
+    constants.PYTORCHJOB_GROUP_LABEL: 'kubeflow.org',
+    constants.PYTORCHJOB_CONTROLLER_LABEL: 'pytorch-operator',
+    constants.PYTORCHJOB_NAME_LABEL: name,
+  }
+
+  if master:
+    labels[constants.PYTORCHJOB_ROLE_LABEL] = 'master'
+
+  if replica_type:
+    labels[constants.PYTORCHJOB_TYPE_LABEL] = str.lower(replica_type)
+
+  if replica_index:
+    labels[constants.PYTORCHJOB_INDEX_LABEL] = replica_index
+
+  return labels
+
+
+def to_selector(labels):
+  """
+  Transfer Labels to selector.
+  """
+  parts = []
+  for key in labels.keys():
+    parts.append("{0}={1}".format(key, labels[key]))
+
+  return ",".join(parts)

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -25,7 +25,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
   name='kubeflow-pytorchjob',
-  version='0.1.2',
+  version='0.1.3',
   author="Kubeflow Authors",
   author_email='hejinchi@cn.ibm.com',
   license='Apache License Version 2.0',

--- a/sdk/python/test/test_e2e.py
+++ b/sdk/python/test/test_e2e.py
@@ -76,4 +76,6 @@ def test_sdk_e2e():
                                          namespace=SDK_TEST_NAMESPACE):
     raise RuntimeError("The PyTorchJob is not succeeded.")
 
+  PYTORCH_CLIENT.get_logs("pytorchjob-mnist-ci-test", namespace=SDK_TEST_NAMESPACE)
+
   PYTORCH_CLIENT.delete("pytorchjob-mnist-ci-test", namespace=SDK_TEST_NAMESPACE)


### PR DESCRIPTION
`kubeflow-pytorchjob` SDK supports getting training process or logs and pod name of the PyTorchJob. 

Related with https://github.com/kubeflow/tf-operator/issues/1129