### PR TITLE
Updated the Docker Image with the Latest one that uses GPU as of PR #255

### DIFF
--- a/examples/mnist/Dockerfile
+++ b/examples/mnist/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:1.0-cuda10.0-cudnn7-runtime
+FROM kubeflow/pytorch:1.0-cuda10.0-cudnn7-runtime
 
 RUN pip install tensorboardX==1.6.0
 WORKDIR /var


### PR DESCRIPTION
Updated the docker image from pytorch/pytorch:1.0-cuda10.0-cudnn7-runtime to kubeflow/pytorch:1.0-cuda10.0-cudnn7-runtime as the pytorch/pytorch:1.0-cuda10.0-cudnn7-runtime is not GPU compatible.Hence using the Docker Image of PR #255.