### PR TITLE
pin kubenertes client version to work around a bug

### DIFF
--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -1,7 +1,7 @@
-certifi >= 14.05.14
-six >= 1.10
-python_dateutil >= 2.5.3
-setuptools >= 21.0.0
-urllib3 >= 1.15.1
-kubernetes>=10.0.1
+certifi>=14.05.14
+six>=1.10
+python_dateutil>=2.5.3
+setuptools>=21.0.0
+urllib3>=1.15.1
+kubernetes==10.0.1
 table_logger>=0.3.5

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -25,7 +25,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
   name='kubeflow-pytorchjob',
-  version='0.1.3',
+  version='0.1.4',
   author="Kubeflow Authors",
   author_email='hejinchi@cn.ibm.com',
   license='Apache License Version 2.0',


### PR DESCRIPTION
There is a problem in new kubenertes Client v11.0.0: https://github.com/kubernetes-client/python/issues/1112

The PR is going to pin the kubenertes Client to 10.0.1 to avoid the issue. Thanks