### PR TITLE
Fix minor OpenShift issues - resource requests, Dockerfile

### DIFF
--- a/examples/mnist/Dockerfile
+++ b/examples/mnist/Dockerfile
@@ -1,7 +1,12 @@
 FROM pytorch/pytorch:1.0-cuda10.0-cudnn7-runtime
 
 RUN pip install tensorboardX==1.6.0
-WORKDIR /var
-ADD mnist.py /var
+RUN mkdir -p /opt/mnist
 
-ENTRYPOINT ["python", "/var/mnist.py"]
+WORKDIR /opt/mnist/src
+ADD mnist.py /opt/mnist/src/mnist.py
+
+RUN  chgrp -R 0 /opt/mnist \
+  && chmod -R g+rwX /opt/mnist
+
+ENTRYPOINT ["python", "/opt/mnist/src/mnist.py"]

--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -18,6 +18,7 @@ rules:
   resources:
   - pytorchjobs
   - pytorchjobs/status
+  - pytorchjobs/finalizers
   verbs:
   - '*'
 - apiGroups:

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -13,10 +13,10 @@ var initContainerTemplate = `
   resources:
     limits:
       cpu: 100m
-      memory: 10Mi
+      memory: 20Mi
     requests:
-      cpu: 10m
-      memory: 1Mi
+      cpu: 50m
+      memory: 10Mi
   command: ['sh', '-c', 'until nslookup {{.MasterAddr}}; do echo waiting for master; sleep 2; done;']`
 
 func init() {


### PR DESCRIPTION
Hi, I'd like to propose these three changes to get pytorch operator and example working on OpenShift

The Dockerfile change is required because containers run as non-root user in OpenShift and the mnist.py needs to create some directories and files

The config.go is necessary because OpenShift has some minimial values set so we need to get over those values.

The rbac.yaml adds a missing resource which is needed in OpenShift to successfully operate the CRs
