### PR TITLE
fix Dockerfile-mpi download miniconda.sh

### DIFF
--- a/examples/mnist/Dockerfile-mpi
+++ b/examples/mnist/Dockerfile-mpi
@@ -24,7 +24,7 @@ ENV PATH="$PATH:/home/.openmpi/bin"
 ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/home/.openmpi/lib/"
 
 RUN ompi_info --parsable --all | grep mpi_built_with_cuda_support:value
-RUN curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
+RUN wget -O ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \


### PR DESCRIPTION
(curl -o -O) it's not work when I built image of mpi at aliyun