### PR TITLE
Update swagger-codegen-cli URL

### DIFF
--- a/hack/python-sdk/gen-sdk.sh
+++ b/hack/python-sdk/gen-sdk.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SWAGGER_JAR_URL="http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.6/swagger-codegen-cli-2.4.6.jar"
+SWAGGER_JAR_URL="http://search.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.6/swagger-codegen-cli-2.4.6.jar"
 SWAGGER_CODEGEN_JAR="hack/python-sdk/swagger-codegen-cli.jar"
 SWAGGER_CODEGEN_CONF="hack/python-sdk/swagger_config.json"
 SWAGGER_CODEGEN_FILE="pkg/apis/pytorch/v1/swagger.json"


### PR DESCRIPTION
The PR is going to fix one out-of-date link, see more in https://github.com/kubeflow/tf-operator/issues/1166