### PR TITLE
Fix Unit Tests

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -238,6 +238,7 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kubeflow/common v0.1.0 h1:2o8GRPzyRZ1eA09i/wT3EhK+3glNq86+8SEqm0kN1Nk=
 github.com/kubeflow/common v0.1.0/go.mod h1:KRw7y0Y6NLz+H+DBqnzljPwIDUuaCWi4cCzCItX1gv8=
+github.com/kubeflow/tf-operator v0.5.3 h1:Ejn5vEAwHBKHU2sJTlUIRpezqIX3WeqXZ2dZx6zn6vY=
 github.com/kubeflow/tf-operator v1.0.0-rc.0.0.20190916040037-5adee6f30c86 h1:IKqVaxwYQgT830uHh/3x+22Lj+kiRcHcGq/OfORStmw=
 github.com/kubeflow/tf-operator v1.0.0-rc.0.0.20190916040037-5adee6f30c86/go.mod h1:EBtz5LQoKaHUl/5fV5vD1qXVNVNyn3TrFaH6eVoQ8SY=
 github.com/kubernetes-sigs/kube-batch v0.4.2 h1:CcFsYiHz1d9adH/jz7nFmjkdZnkPoq9oaWBLBVp5kms=

--- a/go.sum
+++ b/go.sum
@@ -238,7 +238,6 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kubeflow/common v0.1.0 h1:2o8GRPzyRZ1eA09i/wT3EhK+3glNq86+8SEqm0kN1Nk=
 github.com/kubeflow/common v0.1.0/go.mod h1:KRw7y0Y6NLz+H+DBqnzljPwIDUuaCWi4cCzCItX1gv8=
-github.com/kubeflow/tf-operator v0.5.3 h1:Ejn5vEAwHBKHU2sJTlUIRpezqIX3WeqXZ2dZx6zn6vY=
 github.com/kubeflow/tf-operator v1.0.0-rc.0.0.20190916040037-5adee6f30c86 h1:IKqVaxwYQgT830uHh/3x+22Lj+kiRcHcGq/OfORStmw=
 github.com/kubeflow/tf-operator v1.0.0-rc.0.0.20190916040037-5adee6f30c86/go.mod h1:EBtz5LQoKaHUl/5fV5vD1qXVNVNyn3TrFaH6eVoQ8SY=
 github.com/kubernetes-sigs/kube-batch v0.4.2 h1:CcFsYiHz1d9adH/jz7nFmjkdZnkPoq9oaWBLBVp5kms=

--- a/pkg/controller.v1/pytorch/job.go
+++ b/pkg/controller.v1/pytorch/job.go
@@ -2,8 +2,8 @@ package pytorch
 
 import (
 	"fmt"
-	"time"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -12,8 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 
-	pyv1 "github.com/kubeflow/pytorch-operator/pkg/apis/pytorch/v1"
 	common "github.com/kubeflow/common/job_controller/api/v1"
+	pyv1 "github.com/kubeflow/pytorch-operator/pkg/apis/pytorch/v1"
 	pylogger "github.com/kubeflow/tf-operator/pkg/logger"
 	"github.com/kubeflow/tf-operator/pkg/util/k8sutil"
 	"github.com/prometheus/client_golang/prometheus"
@@ -150,7 +150,7 @@ func (pc *PyTorchController) updatePyTorchJob(old, cur interface{}) {
 }
 
 // deletePodsAndServices deletes all the pods and master service.
-func (pc *PyTorchController) deletePodsAndServices(job *pyv1.PyTorchJob, pods []*v1.Pod,services []*v1.Service) error {
+func (pc *PyTorchController) deletePodsAndServices(job *pyv1.PyTorchJob, pods []*v1.Pod, services []*v1.Service) error {
 	if len(pods) == 0 {
 		return nil
 	}
@@ -175,7 +175,7 @@ func (pc *PyTorchController) deletePodsAndServices(job *pyv1.PyTorchJob, pods []
 	if err != nil {
 		return err
 	}
-	for _,service :=range services{
+	for _, service := range services {
 		if err := pc.ServiceControl.DeleteService(service.Namespace, service.Name, job); err != nil {
 			return err
 		}


### PR DESCRIPTION
Related: https://github.com/kubeflow/pytorch-operator/issues/292.

I was able to run unit test locally after these changes .

1. I changed `expectedServiceDeletions` from 0 to 1. Here: https://github.com/kubeflow/pytorch-operator/blob/master/pkg/controller.v1/pytorch/job.go#L163-L171, we don't check that `job.Spec.CleanPodPolicy == common.CleanPodPolicyRunning` before deleting services. 
@jiaqianjing is that correct behaviour? In TF operator we have one loop for services and pods: https://github.com/kubeflow/tf-operator/blob/master/pkg/controller.v1/tensorflow/job.go#L162-L172, but in PyTorch operator we analyse services and pods in the different loops.

2. To fix this error: `Fail in goroutine after TestCopyLabelsAndAnnotation has completed`, I changed run test controller, like here: https://github.com/kubeflow/pytorch-operator/blob/master/pkg/controller.v1/pytorch/controller_test.go#L341-L347.

Do you know how we can add travis check before PR submission?

/assign @gaocegege @johnugeorge 
/cc @jiaqianjing
