### PR TITLE
Change cluster version to 1.16 for e2e test

### DIFF
--- a/scripts/create-cluster.sh
+++ b/scripts/create-cluster.sh
@@ -17,7 +17,6 @@
 # This shell script is used to build a cluster and create a namespace from our
 # argo workflow
 
-
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -29,11 +28,11 @@ NAMESPACE="${DEPLOY_NAMESPACE}"
 
 echo "Activating service-account"
 gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
-echo "Creating GPU cluster"
+echo "Creating CPU cluster"
 gcloud --project ${PROJECT} beta container clusters create ${CLUSTER_NAME} \
     --zone ${ZONE} \
     --accelerator type=nvidia-tesla-k80,count=1 \
-    --cluster-version 1.14
+    --cluster-version 1.16
 echo "Configuring kubectl"
 gcloud --project ${PROJECT} container clusters get-credentials ${CLUSTER_NAME} \
     --zone ${ZONE}

--- a/scripts/create-cluster.sh
+++ b/scripts/create-cluster.sh
@@ -28,7 +28,7 @@ NAMESPACE="${DEPLOY_NAMESPACE}"
 
 echo "Activating service-account"
 gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
-echo "Creating CPU cluster"
+echo "Creating GPU cluster"
 gcloud --project ${PROJECT} beta container clusters create ${CLUSTER_NAME} \
     --zone ${ZONE} \
     --accelerator type=nvidia-tesla-k80,count=1 \


### PR DESCRIPTION
GKE no longer supports 1.14 k8s version.
Ref: https://cloud.google.com/kubernetes-engine/docs/release-notes#august_27_2020_r28.

/assign @gaocegege @johnugeorge 