### PR TITLE
Add test friendly manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ This repository contains the specification and implementation of `PyTorchJob` cu
 
   Please refer to the installation instructions in the [Kubeflow user guide](https://www.kubeflow.org/docs/started/getting-started/). This installs `pytorchjob` CRD and `pytorch-operator` controller to manage the lifecycle of PyTorch jobs.
 
+```
+kubectl apply -k manifests/
+```
+
 ## Creating a PyTorch Job
 
 You can create PyTorch Job by defining a PyTorchJob config file. See the manifests for the [distributed MNIST example](./examples/mnist/). You may change the config file based on your requirements.

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+- crd.yaml
+- namespace.yaml
+- rbac.yaml
+- deployment.yaml
+- service.yaml
+commonLabels:
+  kustomize.component: pytorch-operator
+images:
+- name: gcr.io/kubeflow-images-public/pytorch-operator
+  newName: gcr.io/kubeflow-images-public/pytorch-operator
+  newTag: latest


### PR DESCRIPTION
Resolve #302 

1. We can use `kubectl apply -k manifests/` to deploy pytorch-operator now. 
2. Images can be changed by following commands. 

```
kustomize edit set image gcr.io/kubeflow-images-public/pytorch-operator=${REGISTRY}/pytorch-operator:$(TAG)
```

This will be used to deprecate https://github.com/kubeflow/pytorch-operator/blob/master/scripts/setup-kubeflow.sh later. 

test scripts will be in separate PR along with other changes