### PR TITLE
Add @andreyvelich to approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,7 @@
 approvers:
-  - gaocegege
-  - johnugeorge
-  - Jeffwan
-reviewers:
   - andreyvelich
+  - gaocegege
+  - Jeffwan
+  - johnugeorge
+reviewers:
   - jinchihe


### PR DESCRIPTION
I moved myself from reviews to approvers list to help with `/approve` current PRs.
As well, alphabetise the list.

/assign @johnugeorge @gaocegege @Jeffwan 