### PR TITLE
Temporarily disable mnist test case

### DIFF
--- a/scripts/v1/run-cleanpodpolicy-all.sh
+++ b/scripts/v1/run-cleanpodpolicy-all.sh
@@ -36,6 +36,7 @@ echo "Running smoke test"
 SENDRECV_TEST_IMAGE_TAG="pytorch-dist-sendrecv-test:v1.0"
 go run ./test/e2e/v1/cleanpolicy/cleanpolicy_all.go --namespace=${NAMESPACE} --image=${REGISTRY}/${SENDRECV_TEST_IMAGE_TAG} --name=sendrecvjob-cleanall
 
-echo "Running mnist test"
-MNIST_TEST_IMAGE_TAG="pytorch-dist-mnist-test:v1.0"
-go run ./test/e2e/v1/cleanpolicy/cleanpolicy_all.go --namespace=${NAMESPACE} --image=${REGISTRY}/${MNIST_TEST_IMAGE_TAG} --name=mnistjob-cleanall
+# TODO(Jeffwan@): Enable mnist test once mnist server is back
+#echo "Running mnist test"
+#MNIST_TEST_IMAGE_TAG="pytorch-dist-mnist-test:v1.0"
+#go run ./test/e2e/v1/cleanpolicy/cleanpolicy_all.go --namespace=${NAMESPACE} --image=${REGISTRY}/${MNIST_TEST_IMAGE_TAG} --name=mnistjob-cleanall

--- a/scripts/v1/run-defaults.sh
+++ b/scripts/v1/run-defaults.sh
@@ -36,6 +36,7 @@ echo "Running smoke test"
 SENDRECV_TEST_IMAGE_TAG="pytorch-dist-sendrecv-test:v1.0"
 go run ./test/e2e/v1/default/defaults.go --namespace=${NAMESPACE} --image=${REGISTRY}/${SENDRECV_TEST_IMAGE_TAG} --name=sendrecvjob-cleannone
 
-echo "Running mnist test"
-MNIST_TEST_IMAGE_TAG="pytorch-dist-mnist-test:v1.0"
-go run ./test/e2e/v1/default/defaults.go --namespace=${NAMESPACE} --image=${REGISTRY}/${MNIST_TEST_IMAGE_TAG} --name=mnistjob-cleannone
+# TODO(Jeffwan@): Enable mnist test once mnist server is back
+#echo "Running mnist test"
+#MNIST_TEST_IMAGE_TAG="pytorch-dist-mnist-test:v1.0"
+#go run ./test/e2e/v1/default/defaults.go --namespace=${NAMESPACE} --image=${REGISTRY}/${MNIST_TEST_IMAGE_TAG} --name=mnistjob-cleannone


### PR DESCRIPTION
As mnist dataset server is not stable, pytorch-operator CI job is affected which blocks PR merge. I will temporarily disable it and bring it back later with the improvement

See following links for more details

https://discuss.pytorch.org/t/mnist-server-down/114433
https://github.com/pytorch/vision/issues/3554

Signed-off-by: Jiaxin Shan <seedjeffwan@gmail.com>