### PR TITLE
Fix 'Invalid Pointer' error when PytorchJob is deleted

### DIFF
--- a/pkg/controller.v1/pytorch/controller.go
+++ b/pkg/controller.v1/pytorch/controller.go
@@ -246,7 +246,12 @@ func (pc *PyTorchController) processNextWorkItem() bool {
 	if err != nil {
 		if err == errNotExists {
 			logger.Infof("PyTorchJob has been deleted: %v", key)
-			pytorchJobsDeletedCount.WithLabelValues(pytorchJob.Namespace).Inc()
+			namespace, _, keyerr := cache.SplitMetaNamespaceKey(key)
+			if keyerr == nil && len(namespace) != 0 {
+				pytorchJobsDeletedCount.WithLabelValues(namespace).Inc()
+			} else {
+				logger.Errorf("Invalid PyTorchJob key %s: Namespace is missing %v", key, keyerr)
+			}
 			return true
 		}
 


### PR DESCRIPTION
Fixes `Invalid Pointer` error when `PytorchJob` is deleted.

Based on the fix from `tf-operator`: https://github.com/kubeflow/tf-operator/pull/1285 
